### PR TITLE
refactor: dogfood PatternKit MCP registry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.76.0" />
+    <PackageVersion Include="PatternKit.Core" Version="0.147.1" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="YamlDotNet" Version="18.0.0" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An extensible toolkit for [Microsoft Semantic Kernel](https://github.com/microso
 - 📝 **Skills** — Parse `SKILL.md` files (YAML frontmatter + markdown) into `KernelFunction` or `PromptTemplate`
 - 🔗 **Hooks** — Map Claude Code lifecycle events (`PreToolUse`, `PostToolUse`, etc.) to SK's `IFunctionInvocationFilter` and `IPromptRenderFilter`
 - 📦 **Plugins** — Load `.claude-plugin/` directories with skills, hooks, and MCP configs
+- 🔌 **MCP** — Discover MCP servers from Claude Code, Claude Desktop, VS Code, Codex, Copilot, and JD canonical config with a PatternKit-backed provider chain
 - 🗜️ **Compaction** — Transparent context window management with configurable triggers and hierarchical summarization
 - 🧠 **Memory** — Semantic memory with MMR reranking, temporal decay scoring, and query expansion
 - 💾 **Memory.Sqlite** — SQLite-backed persistent memory storage

--- a/src/JD.SemanticKernel.Extensions.Mcp/JD.SemanticKernel.Extensions.Mcp.csproj
+++ b/src/JD.SemanticKernel.Extensions.Mcp/JD.SemanticKernel.Extensions.Mcp.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.SemanticKernel" />
+    <PackageReference Include="PatternKit.Core" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 

--- a/src/JD.SemanticKernel.Extensions.Mcp/Registry/McpRegistry.cs
+++ b/src/JD.SemanticKernel.Extensions.Mcp/Registry/McpRegistry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using PatternKit.Behavioral.Chain;
 
 namespace JD.SemanticKernel.Extensions.Mcp.Registry;
 
@@ -37,21 +38,22 @@ public sealed class McpRegistry : IMcpRegistry
         CancellationToken cancellationToken = default)
     {
         var merged = new Dictionary<string, McpServerDefinition>(StringComparer.OrdinalIgnoreCase);
+        var state = new McpDiscoveryState(merged);
+        var chainBuilder = AsyncActionChain<McpDiscoveryState>.Create();
 
         foreach (var provider in _providers)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var servers = await provider.DiscoverAsync(cancellationToken).ConfigureAwait(false);
-
-            foreach (var server in servers)
+            chainBuilder.Use(async (current, token, next) =>
             {
-                if (!merged.TryGetValue(server.Name, out var existing) ||
-                    server.Scope > existing.Scope)
-                {
-                    merged[server.Name] = server;
-                }
-            }
+                token.ThrowIfCancellationRequested();
+                var servers = await provider.DiscoverAsync(token).ConfigureAwait(false);
+                current.Merge(servers);
+                await next(current, token).ConfigureAwait(false);
+            });
         }
+
+        var chain = chainBuilder.Build();
+        await chain.ExecuteAsync(state, cancellationToken).ConfigureAwait(false);
 
         return new List<McpServerDefinition>(merged.Values).AsReadOnly();
     }
@@ -75,5 +77,27 @@ public sealed class McpRegistry : IMcpRegistry
         }
 
         return null;
+    }
+
+    private sealed class McpDiscoveryState
+    {
+        private readonly Dictionary<string, McpServerDefinition> _merged;
+
+        public McpDiscoveryState(Dictionary<string, McpServerDefinition> merged)
+        {
+            _merged = merged;
+        }
+
+        public void Merge(IEnumerable<McpServerDefinition> servers)
+        {
+            foreach (var server in servers)
+            {
+                if (!_merged.TryGetValue(server.Name, out var existing) ||
+                    server.Scope > existing.Scope)
+                {
+                    _merged[server.Name] = server;
+                }
+            }
+        }
     }
 }

--- a/tests/JD.SemanticKernel.Extensions.Mcp.Tests/McpRegistryTests.cs
+++ b/tests/JD.SemanticKernel.Extensions.Mcp.Tests/McpRegistryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -103,6 +104,27 @@ public class McpRegistryTests
         var results = await registry.GetAllAsync();
 
         Assert.Single(results);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_CancellationStopsPatternKitDiscoveryChain()
+    {
+        var cts = new CancellationTokenSource();
+        var p1 = Substitute.For<IMcpDiscoveryProvider>();
+        p1.DiscoverAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            cts.Cancel();
+            return new List<McpServerDefinition> { MakeServer("server-a", "p1", McpScope.User) };
+        });
+
+        var p2 = Substitute.For<IMcpDiscoveryProvider>();
+        p2.DiscoverAsync(Arg.Any<CancellationToken>()).Returns(
+            new List<McpServerDefinition> { MakeServer("server-b", "p2", McpScope.User) });
+
+        var registry = new McpRegistry(new[] { p1, p2 });
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => registry.GetAllAsync(cts.Token));
+        await p2.DidNotReceive().DiscoverAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- replace the MCP registry provider aggregation loop with a PatternKit AsyncActionChain
- keep scope precedence and first-writer same-scope behavior intact
- add cancellation coverage for the provider chain
- document the PatternKit-backed MCP discovery path in the README

Closes #64

## Validation
- dotnet restore JD.SemanticKernel.Extensions.slnx
- dotnet build JD.SemanticKernel.Extensions.slnx --configuration Release --no-restore
- dotnet test tests\JD.SemanticKernel.Extensions.Mcp.Tests\JD.SemanticKernel.Extensions.Mcp.Tests.csproj --configuration Release --no-build
- dotnet test JD.SemanticKernel.Extensions.slnx --configuration Release --no-build --verbosity minimal
- git diff --check